### PR TITLE
POC for generic authorisation checks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,12 +123,39 @@ class oAuth2JWTMethod extends Method {
 				return callback(err);
 			}
 
-			callback(null, payload);
+			const scopes = ('scopes' in payload && Array.isArray(payload.scopes)) ? payload.scopes : [];
+			const auth = new ScopeBasedAuthorisation(scopes);
+
+			callback(null, auth);
 		});
 	}
 }
 
+class Authorisation {
+	canReadPartnerInformation(partnerId) {
+		throw new Error('Missing implementation');
+	}
+}
+
+class ScopeBasedAuthorisation extends Authorisation {
+	constructor(scopes = []) {
+		super();
+		this.scopes = scopes;
+	}
+
+	canReadPartnerInformation(partnerId) {
+		return this._hasScope(`partner.${partnerId}.read`);
+	}
+
+	_hasScope(scope) {
+		return this.scopes.indexOf(scope) !== -1;
+	}
+}
+
 module.exports.Provider = Provider;
+module.exports.Authorisation = {
+	ScopeBased: ScopeBasedAuthorisation
+};
 module.exports.Method = {
 	Method: Method,
 	oAuth2JWT: oAuth2JWTMethod

--- a/tests/spec/index.spec.js
+++ b/tests/spec/index.spec.js
@@ -103,4 +103,19 @@ describe('Auth', function () {
 			});
 		});
 	});
+	describe('Authorisation', function () {
+		describe('ScopeBased', function () {
+			it('permits partner reads if the associated scope is held', function() {
+				const partnerId = 'K97777';
+				const authz = new authModule.Authorisation.ScopeBased([`partner.${partnerId}.read`]);
+
+				expect(authz.canReadPartnerInformation(partnerId)).to.equal(true);
+			});
+			it('does not permit partner reads if the associated scope is not held', function() {
+				const authz = new authModule.Authorisation.ScopeBased([`partner.K97777.read`]);
+
+				expect(authz.canReadPartnerInformation('123')).to.equal(false);
+			});
+		})
+	})
 });


### PR DESCRIPTION
CC @michael-donat + @msojda 

Just an idea... I've kept it simple, naming can probably be improved. So `Authorisation` presents a generic interface, meaning consumers of the lib will not need to tie their implementations to usage of scopes.