### PR TITLE
Add original authentication credentials to request auth context.

### DIFF
--- a/tests/functional/index.spec.js
+++ b/tests/functional/index.spec.js
@@ -25,6 +25,7 @@ describe('Auth', function () {
 
         this.auth.middleware()(request, response, () => {
           expect(request.auth).to.have.property('foo', 'bar');
+          expect(request.auth).to.have.property('credentials');
           done();
         });
       });
@@ -48,14 +49,18 @@ describe('Auth', function () {
         const key = fs.readFileSync(path.join(__dirname, '../resources/private.key'));
         const payload = { foo: 'bar' };
         const token = jwt.sign(payload, key, { algorithm: 'RS256'});
+        const header = `Bearer ${token}`;
 
         const oauthMethod = new authModule.Method.oAuth2JWT({
           key: authModule.Key.fromFile(path.join(__dirname, '../resources/public.pem')),
           algo: [authModule.Key.RS256]
         });
 
-        oauthMethod.execute({authorization: `Bearer ${token}`}, (err, result) => {
+        oauthMethod.execute({authorization: header}, (err, result, credentials) => {
           expect(result).to.have.property('foo', 'bar');
+          expect(credentials.source).to.equal('header');
+          expect(credentials.key).to.equal('authorization');
+          expect(credentials.value).to.equal(header);
           expect(err).to.be.null;
           done();
         });

--- a/tests/spec/index.spec.js
+++ b/tests/spec/index.spec.js
@@ -40,13 +40,15 @@ describe('Auth', function () {
 				stub.applies = () => true;
 
 				stub.execute = function([], callback) {
-					callback(null, 123);
+					callback(null, 123, 456);
 				};
 
-				provider.execute([], (err, result) => {
+				provider.execute([], (err, result, credentials) => {
 					expect(err).to.not.exist;
 					expect(result).to.exist
 						.and.to.be.equal(123);
+					expect(credentials).to.exist
+						.and.to.be.equal(456);
 						done();
 				});
 			});


### PR DESCRIPTION
This resolves #3, at least in a way that feels suitable right now.